### PR TITLE
add pagination to page if page-pagination attribute is set

### DIFF
--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -7,4 +7,5 @@
 {{/if}}
 {{> contributor-bot}}
 {{{page.contents}}}
+{{> pagination}}
 </article>

--- a/src/partials/pagination.hbs
+++ b/src/partials/pagination.hbs
@@ -1,0 +1,12 @@
+{{#unless (eq page.attributes.pagination undefined)}}
+{{#if (or page.previous page.next)}}
+<nav class="pagination">
+  {{#with page.previous}}
+  <span class="prev"><a href="{{{relativize ./url}}}">{{{./content}}}</a></span>
+  {{/with}}
+  {{#with page.next}}
+  <span class="next"><a href="{{{relativize ./url}}}">{{{./content}}}</a></span>
+  {{/with}}
+</nav>
+{{/if}}
+{{/unless}}


### PR DESCRIPTION
This PR adds the template logic to enable pagination between adjacent pages in the navigation. It does not include the CSS. The CSS will need to be added by the design team for these links to display properly. Here's an idea for how to style them: https://www.uyuni-project.org/uyuni-docs/uyuni/installation/install-intro.html