### PR TITLE
Adding options to  pagination.hbs

### DIFF
--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -2,7 +2,7 @@
 :doctype: book
 :page-edition: enterprise
 :page-status: beta
-:page-pagination:
+:page-pagination: next
 
 // The following should be global document attributes
 :url-edition: https://www.couchbase.com/products/editions

--- a/src/partials/head-meta.hbs
+++ b/src/partials/head-meta.hbs
@@ -14,6 +14,47 @@
         <link rel="next" href="{{{relativize ./url}}}">
     {{/with}}
 {{/unless}}
+
+{{#unless (eq page.attributes.pagination undefined)}}
+
+    {{#if (or page.previous page.next)}}
+
+        {{#if (eq page.attributes.pagination 'full') }}
+            {{#with page.previous}}
+                    <link rel="prev" href="{{{relativize ./url}}}">
+            {{/with}}
+
+        {{ else if (eq page.attributes.pagination '') }}
+            {{#with page.previous}}
+                <link rel="prev" href="{{{relativize ./url}}}">
+            {{/with}}
+
+        {{ else if (eq page.attributes.pagination 'prev') }}
+            {{#with page.previous}}
+                    <link rel="prev" href="{{{relativize ./url}}}">
+            {{/with}}
+
+        {{/if}}
+
+        {{#if (eq page.attributes.pagination 'full') }}
+            {{#with page.next}}
+                    <link rel="next" href="{{{relativize ./url}}}">
+            {{/with}}
+
+        {{ else if (eq page.attributes.pagination '') }}
+            {{#with page.next}}
+                <link rel="next" href="{{{relativize ./url}}}">
+            {{/with}}
+
+        {{ else if (eq page.attributes.pagination 'next') }}
+            {{#with page.next}}
+                    <link rel="next" href="{{{relativize ./url}}}">
+            {{/with}}
+
+        {{/if}}
+    {{/if}}
+{{/unless}}
+
 <meta name="dcterms.subject" content="{{page.component.name}}">
 <meta name="dcterms.identifier" content="{{page.version}}">
 <meta name="page-url" content="{{page.url}}">

--- a/src/partials/pagination.hbs
+++ b/src/partials/pagination.hbs
@@ -33,7 +33,7 @@
             {{/with}}
 
         {{ else if (eq page.attributes.pagination 'next') }}
-            {{#with page.previous}}
+            {{#with page.next}}
                     <span class="next"><a href="{{{relativize ./url}}}">{{{./content}}}</a></span>
             {{/with}}
 

--- a/src/partials/pagination.hbs
+++ b/src/partials/pagination.hbs
@@ -1,12 +1,45 @@
 {{#unless (eq page.attributes.pagination undefined)}}
-{{#if (or page.previous page.next)}}
-<nav class="pagination">
-  {{#with page.previous}}
-  <span class="prev"><a href="{{{relativize ./url}}}">{{{./content}}}</a></span>
-  {{/with}}
-  {{#with page.next}}
-  <span class="next"><a href="{{{relativize ./url}}}">{{{./content}}}</a></span>
-  {{/with}}
-</nav>
-{{/if}}
+
+    {{#if (or page.previous page.next)}}
+        <nav class="pagination">
+
+        {{#if (eq page.attributes.pagination 'full') }}
+            {{#with page.previous}}
+                    <span class="prev"><a href="{{{relativize ./url}}}">{{{./content}}}</a></span>
+            {{/with}}
+
+        {{ else if (eq page.attributes.pagination '') }}
+            {{#with page.previous}}
+                    <span class="prev"><a href="{{{relativize ./url}}}">{{{./content}}}</a></span>
+            {{/with}}
+
+        {{ else if (eq page.attributes.pagination 'prev') }}
+            {{#with page.previous}}
+                    <span class="prev"><a href="{{{relativize ./url}}}">{{{./content}}}</a></span>
+            {{/with}}
+
+        {{else}}
+                <span>&nbsp;</span>
+        {{/if}}
+
+        {{#if (eq page.attributes.pagination 'full') }}
+            {{#with page.next}}
+                    <span class="next"><a href="{{{relativize ./url}}}">{{{./content}}}</a></span>
+            {{/with}}
+
+        {{ else if (eq page.attributes.pagination '') }}
+            {{#with page.next}}
+                    <span class="next"><a href="{{{relativize ./url}}}">{{{./content}}}</a></span>
+            {{/with}}
+
+        {{ else if (eq page.attributes.pagination 'next') }}
+            {{#with page.previous}}
+                    <span class="next"><a href="{{{relativize ./url}}}">{{{./content}}}</a></span>
+            {{/with}}
+
+        {{else}}
+                <span>&nbsp;</span>
+            </nav>
+        {{/if}}
+    {{/if}}
 {{/unless}}


### PR DESCRIPTION
Adding a few option to the pagination attribute:

**:page-pagination: full** --> next and previous links

**:page-pagination:** --> next and previous links (for compatibility with Antora default)

**:page-pagination: prev** --> just the previous link

**:page-pagination: next** --> just the next link

