### PR TITLE
POC: optional level-3 TOC

### DIFF
--- a/gulp.d/tasks/build-preview-pages.js
+++ b/gulp.d/tasks/build-preview-pages.js
@@ -121,9 +121,9 @@ module.exports =
                     pageModel.attributes = Object.entries({ ...attributes, ...componentVersion.asciidoc.attributes })
                       .filter(([name, val]) => name.startsWith('page-'))
                       .reduce((accum, [name, val]) => ({ ...accum, [name.substr(5)]: val }), {})
-                    
+
                     // console.log(pageModel.attributes)
-                    
+
                     pageModel.contents = Buffer.from(
                       doc
                         .convert()

--- a/gulp.d/tasks/build-preview-pages.js
+++ b/gulp.d/tasks/build-preview-pages.js
@@ -122,8 +122,6 @@ module.exports =
                       .filter(([name, val]) => name.startsWith('page-'))
                       .reduce((accum, [name, val]) => ({ ...accum, [name.substr(5)]: val }), {})
 
-                    // console.log(pageModel.attributes)
-
                     pageModel.contents = Buffer.from(
                       doc
                         .convert()

--- a/gulp.d/tasks/build-preview-pages.js
+++ b/gulp.d/tasks/build-preview-pages.js
@@ -41,7 +41,12 @@ const requireFromString = require('require-from-string')
 const vfs = require('vinyl-fs')
 const yaml = require('js-yaml')
 
-const ASCIIDOC_ATTRIBUTES = { experimental: '', icons: 'font', sectanchors: '', 'source-highlighter': 'highlight.js' }
+const ASCIIDOC_ATTRIBUTES = {
+  experimental: '',
+  icons: 'font',
+  sectanchors: '',
+  'source-highlighter': 'highlight.js',
+}
 
 module.exports =
   (src, previewSrc, previewDest, sink = () => map()) =>
@@ -116,6 +121,9 @@ module.exports =
                     pageModel.attributes = Object.entries({ ...attributes, ...componentVersion.asciidoc.attributes })
                       .filter(([name, val]) => name.startsWith('page-'))
                       .reduce((accum, [name, val]) => ({ ...accum, [name.substr(5)]: val }), {})
+                    
+                    // console.log(pageModel.attributes)
+                    
                     pageModel.contents = Buffer.from(
                       doc
                         .convert()

--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -514,3 +514,13 @@ http://packages.couchbase.com/clients/kafka/3.2.3/kafka-connect-couchbase-3.2.3.
 == `spec.volumeClaimTemplates.metadata`
 
 This section demonstrates what happens when the section title does not have any natural wrap opportunities.
+
+== Testing level 3 nav
+
+[.include-in-toc]
+=== This is visible
+
+=== (But this is not)
+
+[.include-in-toc]
+=== And so is this

--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -3,6 +3,7 @@
 :page-edition: enterprise
 :page-status: beta
 :page-pagination:
+:page-toclevels: 2
 
 // The following should be global document attributes
 :url-edition: https://www.couchbase.com/products/editions
@@ -515,12 +516,16 @@ http://packages.couchbase.com/clients/kafka/3.2.3/kafka-connect-couchbase-3.2.3.
 
 This section demonstrates what happens when the section title does not have any natural wrap opportunities.
 
-== Testing level 3 nav
+== Testing level 2 nav
 
-[.include-in-toc]
-=== This is visible
+These changes are made in 02-on-this-page.js, which implements support for `:page-toclevels:`
 
-=== (But this is not)
+=== This is level2 
 
-[.include-in-toc]
-=== And so is this
+If a heading starts with 3 equals signs `===` it is level2.
+
+=== So is this
+
+==== But this is level 3
+
+This last section shouldn't show up in the nav.

--- a/src/css/toc.css
+++ b/src/css/toc.css
@@ -112,3 +112,19 @@
   line-height: 1.125;
   color: inherit;
 }
+
+.toc .toc-menu li.toc-H1 {
+  font-weight: bold;
+  font-size: 110%;
+}
+
+.toc .toc-menu li.toc-H3 {
+  list-style-type: circle;
+  margin-left: 1em;
+  font-size: 90%;
+}
+
+.toc ul li.toc-H3 a {
+  padding-top: 0;
+}
+

--- a/src/css/toc.css
+++ b/src/css/toc.css
@@ -128,4 +128,3 @@
 .toc ul li[data-level="2"] a {
   padding-top: 2px;
 }
-

--- a/src/css/toc.css
+++ b/src/css/toc.css
@@ -113,18 +113,19 @@
   color: inherit;
 }
 
-.toc .toc-menu li.toc-H1 {
+/* level 0 = shouldn't be selected at all */
+.toc .toc-menu li[data-level="0"] {
   font-weight: bold;
-  font-size: 110%;
 }
 
-.toc .toc-menu li.toc-H3 {
-  list-style-type: circle;
-  margin-left: 1em;
-  font-size: 90%;
+/* level 2 === */
+.toc .toc-menu li[data-level="2"] {
+  list-style-type: '-';
+  margin-left: 0.5em;
+  padding-left: 0.5em;
 }
 
-.toc ul li.toc-H3 a {
-  padding-top: 0;
+.toc ul li[data-level="2"] a {
+  padding-top: 2px;
 }
 

--- a/src/js/02-on-this-page.js
+++ b/src/js/02-on-this-page.js
@@ -7,7 +7,7 @@
   var headings
   if (
     document.querySelector('.body.-toc') ||
-    !(headings = find('h1[id].sect0, .sect1 > h2[id]', (doc = document.querySelector('article.doc')))).length
+    !(headings = find('h1[id].sect0, .sect1 > h2[id], .sect2.include-in-toc > h3[id]', (doc = document.querySelector('article.doc')))).length
   ) {
     //sidebar.parentNode.removeChild(sidebar) // sidebar is used for other purposes, so leave it
     return
@@ -23,6 +23,7 @@
     }, document.createElement('a'))
     links[(link.href = '#' + heading.id)] = link
     var listItem = document.createElement('li')
+    listItem.className = "toc-" + heading.tagName
     listItem.appendChild(link)
     accum.appendChild(listItem)
     return accum

--- a/src/js/02-on-this-page.js
+++ b/src/js/02-on-this-page.js
@@ -3,17 +3,17 @@
 
   var sidebar = document.querySelector('aside.toc.sidebar')
   if (!sidebar) return
-  
+
   if (document.querySelector('body.-toc')) {
     return // sidebar.parentNode.removeChild(sidebar)
     // sidebar is used for other purposes, so leave it
   }
-  
-  const DEFAULT_LEVEL = 1; // usually 2 in stock Antora, but we don't want === headers by default
+
+  const DEFAULT_LEVEL = 1 // usually 2 in stock Antora, but we don't want === headers by default
 
   var levels = parseInt(sidebar.dataset.levels || DEFAULT_LEVEL, 10)
   if (levels < 0) return
-    
+
   var articleSelector = 'article.doc'
   var article = document.querySelector(articleSelector)
   var headingsSelector = []
@@ -27,19 +27,18 @@
     }
     headingsSelector.push(headingSelector.join('>'))
   }
-  
-  console.log(levels, headingsSelector)
-  
+
+  // console.log(levels, headingsSelector)
+
   var headings = find(headingsSelector.join(','), article.parentNode)
   if (!headings.length) {
     return // sidebar.parentNode.removeChild(sidebar)
     // sidebar is used for other purposes, so leave it
   }
-  
+
   var lastActiveFragment
   var links = {}
-  var menu
-  
+
   var list = headings.reduce(function (accum, heading) {
     var link = document.createElement('a')
     link.textContent = heading.textContent
@@ -56,7 +55,7 @@
     menu = document.createElement('div')
     menu.className = 'toc-menu'
   }
-  
+
   // We don't use the title element at the moment
   // var title = document.createElement('h3')
   // title.textContent = sidebar.dataset.title || 'Contents'
@@ -78,7 +77,6 @@
     embeddedToc.appendChild(menu.cloneNode(true))
     startOfContent.parentNode.insertBefore(embeddedToc, startOfContent)
   }
-
 
   function onScroll () {
     // NOTE doc.parentNode.offsetTop ~= doc.parentNode.getBoundingClientRect().top + window.pageYOffset

--- a/src/partials/toc.hbs
+++ b/src/partials/toc.hbs
@@ -1,4 +1,6 @@
-<aside class="toc sidebar">
+<aside class="toc sidebar"
+      data-title="{{or page.attributes.toctitle 'Contents'}}"
+      data-levels="{{{or page.attributes.toclevels 1}}}">
   <div class="sidebar-box">
     {{> toolbar}}
     <div class="toc-menu"></div>


### PR DESCRIPTION
This commit adds the `[.include-in-toc]` role which will select h3 to be
included in the table of contents.

Basic CSS is provided to differentiate h1, h2, h3.

(No idea if this is the best / a half-reasonable way of doing this, asking @couchbase/docs-writers for review!)