### PR TITLE
DOC-9373 - Update Navigation Buttons to Match www

### DIFF
--- a/src/css/common.css
+++ b/src/css/common.css
@@ -7,16 +7,23 @@
 }
 
 .btn {
-  border-radius: 3px;
   font-family: "Source Sans Pro", sans-serif;
   font-size: 1.125rem;
 }
 
 .btn-primary {
   padding: 5px 15px;
-  border: 1px solid var(--color-brand-blue-secondary);
-  background: var(--color-brand-blue-secondary);
+  font-weight: 600;
+  margin-left: var(--column-space);
+  border: 2px solid var(--color-brand-blue);
+  background: var(--color-brand-blue);
   color: var(--color-brand-white);
+}
+
+.btn-grey-reverse {
+  border: 2px solid var(--color-brand-grey);
+  background: var(--color-brand-white);
+  color: var(--color-brand-grey);
 }
 
 @media screen and (min-width: 768px) {

--- a/src/css/header.css
+++ b/src/css/header.css
@@ -118,31 +118,21 @@
 }
 
 .primary-action .btn:hover {
-  background-color: var(--color-link-hover);
+  background-color: var(--color-brand-white);
+  color: var(--color-brand-blue);
+  text-decoration: none;
+  border-color: var(--color-brand-blue);
+}
+
+.primary-action .btn-grey-reverse:hover {
+  background-color: var(--color-brand-grey);
   color: var(--color-brand-white);
   text-decoration: none;
-  border-color: var(--color-link-hover);
+  border-color: var(--color-brand-grey);
 }
 
 .primary-action > * {
   display: inline-block;
-}
-
-.free-trial-link {
-  font-weight: var(--weight-bold);
-  margin-left: var(--column-space);
-}
-
-.try-btn {
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--color-brand-blue-secondary);
-  text-decoration: none;
-  margin-left: 35px;
-}
-
-.try-btn:hover {
-  text-decoration: none;
 }
 
 .parent-site {

--- a/src/css/header.css
+++ b/src/css/header.css
@@ -128,12 +128,12 @@
   display: inline-block;
 }
 
-.try-btn {
+.free-trial-link {
   font-weight: var(--weight-bold);
   margin-left: var(--column-space);
 }
 
-.free-trial-link {
+.try-btn {
   font-size: 16px;
   font-weight: 600;
   color: var(--color-brand-blue-secondary);
@@ -141,7 +141,7 @@
   margin-left: 35px;
 }
 
-.free-trial-link:hover {
+.try-btn:hover {
   text-decoration: none;
 }
 
@@ -336,13 +336,13 @@
     color: var(--color-brand-white);
   } */
 
-  .try-btn {
+  .free-trial-link {
     background: var(--color-brand-white);
     color: var(--color-brand-blue);
     margin: 0;
   }
 
-  .free-trial-link {
+  .try-btn {
     color: var(--color-brand-white);
   }
 

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -38,6 +38,7 @@
   --color-brand-blue-secondary-light: #2689e5;
   --color-brand-blue-secondary-extra-light: #73b3ee;
   --color-brand-blue-tint: #d9eafb;
+  --color-brand-grey: #666;
   --color-brand-orange: #fc9c0c;
   --color-brand-orange-tint: #fff0da;
   --color-muted: var(--color-brand-gray);

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -60,13 +60,15 @@
                   <input class="dataLayer query" type="text" placeholder="Search Docs"{{#if page.home}} autofocus{{/if}}><i class="fas fa-search"></i>
                 </form>
                 {{/if}}
-                <a href="https://cloud.couchbase.com/sign-up" class="free-trial-link" onclick="(window.dataLayer=window.dataLayer||[]).push({'event':'customEvent', 'category':'CTA', 'action':'Button Click',  'label':'Free Trial'});" >
-                  <i class="fas fa-cloud"></i>
-                  Free Trial
-                </a>
-                <a class="btn btn-primary try-btn"  onclick="(window.dataLayer=window.dataLayer||[]).push({'event':'customEvent', 'category':'CTA', 'action':'Button Click',  'label':'Download'});" href="https://www.couchbase.com/downloads">
+                <a class="try-btn" onclick="(window.dataLayer=window.dataLayer||[]).push({'event':'customEvent', 'category':'CTA', 'action':'Button Click',  'label':'Download'});" href="https://www.couchbase.com/downloads">
                   Downloads
+                  <i class="far fa-arrow-to-bottom fa-lg fa-fw"></i>
                 </a>
+                <a href="https://cloud.couchbase.com/sign-up" class="btn btn-primary free-trial-link" onclick="(window.dataLayer=window.dataLayer||[]).push({'event':'customEvent', 'category':'CTA', 'action':'Button Click',  'label':'Free Trial'});" >
+                  Start Free Trial
+                  <i class="far fa-cloud fa-fw"></i>
+                </a>
+
               </div>
 
         </nav>

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -60,11 +60,11 @@
                   <input class="dataLayer query" type="text" placeholder="Search Docs"{{#if page.home}} autofocus{{/if}}><i class="fas fa-search"></i>
                 </form>
                 {{/if}}
-                <a class="try-btn" onclick="(window.dataLayer=window.dataLayer||[]).push({'event':'customEvent', 'category':'CTA', 'action':'Button Click',  'label':'Download'});" href="https://www.couchbase.com/downloads">
+                <a class="btn btn-primary btn-grey-reverse" onclick="(window.dataLayer=window.dataLayer||[]).push({'event':'customEvent', 'category':'CTA', 'action':'Button Click',  'label':'Download'});" href="https://www.couchbase.com/downloads">
                   Downloads
-                  <i class="far fa-arrow-to-bottom fa-lg fa-fw"></i>
+                  <i class="far fa-arrow-to-bottom fa-fw"></i>
                 </a>
-                <a href="https://cloud.couchbase.com/sign-up" class="btn btn-primary free-trial-link" onclick="(window.dataLayer=window.dataLayer||[]).push({'event':'customEvent', 'category':'CTA', 'action':'Button Click',  'label':'Free Trial'});" >
+                <a href="https://cloud.couchbase.com/sign-up" class="btn btn-primary" onclick="(window.dataLayer=window.dataLayer||[]).push({'event':'customEvent', 'category':'CTA', 'action':'Button Click',  'label':'Free Trial'});" >
                   Start Free Trial
                   <i class="far fa-cloud fa-fw"></i>
                 </a>


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-9373

Pending review of UI changes.

**UPDATE:** Review of UI changes requires the navigation buttons to be the same as [www]( https://www.couchbase.com/).
I've updated the buttons with the following:

- Remove rounded corners to match www design:
<img width="1792" alt="Screen Shot 2022-01-06 at 12 32 25 PM" src="https://user-images.githubusercontent.com/13270204/148383818-fb336c67-7a44-4021-a421-e8f195afe3d2.png">

- When hovering on the `Downloads` button, the background changes to grey:
<img width="1596" alt="Screen Shot 2022-01-06 at 12 32 42 PM" src="https://user-images.githubusercontent.com/13270204/148383962-57ee86c7-adcb-4736-9eca-b4ec4bda3835.png">

- When hovering on the `Start Free Trial` button, the background changes to white, with a blue border:
<img width="1781" alt="Screen Shot 2022-01-06 at 12 32 55 PM" src="https://user-images.githubusercontent.com/13270204/148384096-71d1437a-6ae4-4bfc-b683-150ceb96018a.png">

Tested on Chrome, Safari and Firefox with no issue. 
