### PR TITLE
Add css for disabling callouts

### DIFF
--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -464,7 +464,7 @@ POST http://nodename:8091/settings/viewUpdateDaemon
 updateInterval=10000&updateMinChanges=7000
 ----
 
-[source,json]
+[source,json5, role="no-callouts"]
 ----
 {
    "_id": "_design/myddoc",
@@ -474,11 +474,12 @@ updateInterval=10000&updateMinChanges=7000
       }
    },
    "options": {
-       "updateMinChanges": 1000,
+       "updateMinChanges": 1000,  //<.>
        "replicaUpdateMinChanges": 20000
    }
 }
 ----
+<.> Disable callout test (add or remove `role="no-callouts"` from the above listin to test)
 
 You can set this information when creating and updating design documents through the design document REST API.
 To perform this operation using the `curl` tool:

--- a/src/css/disable-callouts.css
+++ b/src/css/disable-callouts.css
@@ -1,3 +1,3 @@
 .no-callouts .conum {
-    display: none !important;
+  display: none !important;
 }

--- a/src/css/disable-callouts.css
+++ b/src/css/disable-callouts.css
@@ -1,0 +1,3 @@
+.no-callouts .conum {
+    display: none !important;
+}

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -29,3 +29,4 @@
 @import "landing-page.css";
 @import "contributor.css";
 @import "terminal.css";
+@import "disable-callouts.css";


### PR DESCRIPTION
Allows you to add a role to a source block which will hide any callouts it contains.

Use case:

I use a code block the first time with the callouts which explain what the lines do.

On a later page, I may want to refer to the same code block again, as a memory refresher for the reader, but I don't need the callouts because I'm not going to explain everything. 

This would be handy for a tutorial which runs across a number of pages.