### PR TITLE
Change to STEM support: can now be set up on individual pages.

### DIFF
--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -530,7 +530,3 @@ If a heading starts with 3 equals signs `===` it is level2.
 
 This last section shouldn't show up in the nav.
 
-== Stem Test
-
-stem:[sqrt(4) = 2]
-

--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -18,7 +18,7 @@
 <script defer src="{{{uiRootPath}}}/js/vendor/fontawesome.js"></script>
 <script async src="{{{uiRootPath}}}/js/vendor/highlight.js"></script>
 {{#with (resolvePage page.relativeSrcPath model=false)}}
-    {{#unless (eq asciidoc.attributes.stem undefined)}}
+    {{#unless (and (eq asciidoc.attributes.stem undefined) (eq page.attributes.stem undefined))}}
 <script type="text/x-mathjax-config">
 MathJax.Hub.Config({
   messageStyle: "none",


### PR DESCRIPTION
STEM support can now be added globally (by adding the stem attribute to the playbook) or for individual pages (by adding the stem attribute to the page's header).

Also removed the stem test from the preview because the preview can't be used to test it.