### PR TITLE
DOC-10087: Add Noindex to meta

### DIFF
--- a/preview-src/noindex.adoc
+++ b/preview-src/noindex.adoc
@@ -1,0 +1,4 @@
+= Super Secret Content!
+:page-meta-robots: noindex
+
+This content will not be indexed by search engines.

--- a/src/partials/head-meta.hbs
+++ b/src/partials/head-meta.hbs
@@ -1,3 +1,8 @@
+{{#with page.attributes.meta-robots}}
+    {{#unless (eq this undefined)}}
+    <meta name="robots" content="{{this}}">
+    {{/unless}}
+{{/with}}
 {{#with page.description}}
 <meta name="description" content="{{this}}">
 {{/with}}


### PR DESCRIPTION
When `:page-meta-robots: noindex` is set in an asciidoc,
the page should not be indexed.

We use the meta robots tag as per:

    https://developers.google.com/search/docs/advanced/crawling/block-indexing

(though not limited to google)

It looks as though Algolia may also respect this:

    https://www.algolia.com/doc/tools/crawler/apis/configuration/ignore-no-index/

(though may depend on our configuration?)