### PR TITLE
DOC-9494: Disable Search Return

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -56,9 +56,9 @@
               </div>
               <div class="primary-action">
                 {{#if env.ALGOLIA_API_KEY}}
-                <form class="navbar-item search" id="search">
+                <div class="navbar-item search" id="search">
                   <input class="dataLayer query" type="text" placeholder="Search Docs"{{#if page.home}} autofocus{{/if}}><i class="fas fa-search"></i>
-                </form>
+                </div>
                 {{/if}}
                 <a class="btn btn-primary btn-grey-reverse" onclick="(window.dataLayer=window.dataLayer||[]).push({'event':'customEvent', 'category':'CTA', 'action':'Button Click',  'label':'Download'});" href="https://www.couchbase.com/downloads">
                   Downloads


### PR DESCRIPTION
Pressing `<RETURN>` while in the Search bar would simply reload the page.

OpenDevise advised that changing the search html to a form would prevent
this:

* https://support.opendevise.com/support/tickets/146

Have confirmed this testing locally (with `ALGOLIA_API_KEY=dummy`)

Dan's other suggestion about jumping straight to first result looks
good also. This would need testing on Staging
(or locally, having run Algolia. So I'll create and link a separate
ticket for that.)