### PR TITLE
Fix landing page bullet points and weird indentation

### DIFF
--- a/preview-src/landing-page-sdk.adoc
+++ b/preview-src/landing-page-sdk.adoc
@@ -33,7 +33,8 @@ image::sdk-icon.svg[]
 .C SDK
 
 [.content]
-The Couchbase C SDK (libcouchbase) enables C and C++ programs to access a Couchbase Server cluster. The C SDK is also commonly used as a core dependency of SDKs written in other language to provide a common implementation and high performance.
+* The Couchbase C SDK (libcouchbase) enables C and C++ programs to access a Couchbase Server cluster.
+* The C SDK is also commonly used as a core dependency of SDKs written in other language to provide a common implementation and high performance. +
 []
 xref:#[Start Using the C SDK]
 
@@ -45,6 +46,10 @@ xref:#[Start Using the C SDK]
 The .NET SDK enables you to interact with a Couchbase Server cluster from the .NET Framework using any Common Language Runtime (CLR) language, including C#, F#, and VB.NET. It offers both a traditional synchronous API and an asynchronous API based on the Task-based Asynchronous Pattern (TAP).
 []
 xref:#[Start Using the .NET SDK]
+
+* Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+* Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+* Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 
 [.column]
 ====== {empty}

--- a/src/css/landing-page.css
+++ b/src/css/landing-page.css
@@ -182,8 +182,8 @@
 }
 
 .doc.landing-page-doc ul li {
-  list-style: none;
-  margin: 0 0 8px;
+  /* list-style: none; */
+  margin: 0 0 8px 16px;
   font-size: 1rem;
   font-family: "Open Sans", sans-serif;
   color: var(--color-brand-black);
@@ -217,7 +217,7 @@
 
 .card-row .column .content {
   margin-bottom: 16px;
-  display: inline-block;
+  /* display: inline-block; */
   width: 100%;
 }
 


### PR DESCRIPTION
- Fixed weird indentation issues for section title when bullet points are used.
- Show bullet point (for some reason we were hiding it 🤷‍♀️ ).

This will fix all landing pages that use the `landing-page-top-level-sdk` layout.
No other layouts should be affected.