### PR TITLE
DOC-9410: UI changes for code blocks

### DIFF
--- a/src/css/clipboard.css
+++ b/src/css/clipboard.css
@@ -155,13 +155,13 @@ code::-webkit-scrollbar-thumb {
 }
 
 .source-type-box .right-block > * {
-  border-right: 1px solid #e5e5e5;
+  border-left: 1px solid #e5e5e5;
   padding: 4px 10px;
   display: flex;
   align-items: center;
 }
 
-.source-type-box .right-block > *:last-child {
+.source-type-box .right-block > .run-code {
   border: none;
 }
 

--- a/src/css/clipboard.css
+++ b/src/css/clipboard.css
@@ -171,6 +171,7 @@ code::-webkit-scrollbar-thumb {
   font-weight: var(--weight-medium);
 }
 
+.view-source-button .svg-inline--fa,
 .copy-code-button .svg-inline--fa,
 .run-code .svg-inline--fa {
   margin-right: 5px;

--- a/src/css/clipboard.css
+++ b/src/css/clipboard.css
@@ -129,7 +129,7 @@ code::-webkit-scrollbar-thumb {
 
 /* New style code block */
 .source-type-box {
-  padding-left: 12px;
+  padding-left: 6px;
   border: 1px solid #e5e5e5;
   border-bottom: none;
   border-radius: 3px 3px 0 0;
@@ -143,8 +143,15 @@ code::-webkit-scrollbar-thumb {
   position: relative;
 }
 
+.source-type-box .left-block,
 .source-type-box .right-block {
   display: flex;
+}
+
+.source-type-box .left-block > * {
+  padding: 4px 10px;
+  display: flex;
+  align-items: center;
 }
 
 .source-type-box .right-block > * {

--- a/src/js/07-copy-to-clipboard.js
+++ b/src/js/07-copy-to-clipboard.js
@@ -13,6 +13,8 @@
       viewSourceLink.target = '_blank'
       viewSourceLink.dataset.title = 'View On GitHub'
       viewSourceLink.appendChild(document.createElement('i')).className = 'fab fa-github'
+      var viewText = document.createTextNode('View')
+      viewSourceLink.appendChild(viewText)
     }
     var sourceTypeBox = document.createElement('div')
     sourceTypeBox.className = 'source-type-box'

--- a/src/js/07-copy-to-clipboard.js
+++ b/src/js/07-copy-to-clipboard.js
@@ -107,7 +107,7 @@
     pre.prepend(sourceTypeBox)
     sourceTypeBox.appendChild(headingBox)
     sourceTypeBox.appendChild(sourceTypeBoxCol2)
-    sourceTypeBoxCol2.appendChild(dataSource)
+    headingBox.appendChild(dataSource)
     if (viewSourceLink) sourceTypeBoxCol2.appendChild(viewSourceLink)
     sourceTypeBoxCol2.appendChild(copyButton)
     if (runCodeButton) sourceTypeBoxCol2.appendChild(runCodeButton)


### PR DESCRIPTION
Based on feedback from Chin and Dhinu.

* Moved the [source code type label to the left](https://deploy-preview-140--cb-docs-ui.netlify.app/#_try_it_now) to make it clear it's not a clickable button
* Added a [text label](https://deploy-preview-140--cb-docs-ui.netlify.app/#server-stats) to the **View on Github** button to aid discoverability

Docs issue: [DOC-9410](https://issues.couchbase.com/browse/DOC-9410)