### PR TITLE
DOC-10176: Openapi Table CSS

### DIFF
--- a/src/css/table.css
+++ b/src/css/table.css
@@ -119,6 +119,30 @@ table.table-tutorial tr td:last-child {
   font-family: inherit;
 }
 
+/* OpenAPI style tables (to avoid keywords being unpleasantly wrapped/hyphenated) */
+
+/* No maximum width for table cells */
+.openapi table.spread > tbody > tr > *,
+.openapi table.stretch > tbody > tr > * {
+  max-width: none !important;
+}
+
+/* Ignore fixed column widths */
+.openapi table col {
+  width: auto !important;
+}
+
+/* Do not hyphenate words in the table */
+.openapi table td.tableblock p,
+.openapi table p.tableblock {
+  hyphens: manual !important;
+}
+
+/* Vertical alignment */
+.openapi table td.tableblock {
+  vertical-align: top !important;
+}
+
 /* Responsive css  */
 
 @media screen and (min-width: 768px) {


### PR DESCRIPTION
CSS supplied by @simon-dew, to avoid hyphenating/wrapping
keywords at random places.

Tested with Swagger2Markup output and Openapi-Generator:

Good results on Google Chrome
(except for odd formatting of tables at narrow width,
which seems to be artefact of existing responsive table
styling, to be reviewed separately).

Apply as a page role:

  :page-role: openapi

(or presumably a section role etc., the CSS doesn't limit which tag has
the .openapi class)