### PR TITLE
DOC-10177 Improve spacing on horizontal definition lists.

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -591,8 +591,7 @@ ul ul ul {
 
 .hdlist table tr .hdlist1,
 .hdlist table tr .hdlist2 {
-  padding-top: var(--base-small-space);
-  padding-bottom: var(--base-small-space);
+  padding: var(--base-small-space) 0;
 }
 
 .hdlist1,

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -589,6 +589,12 @@ ul ul ul {
   margin-left: var(--base-space);
 }
 
+.hdlist table tr .hdlist1,
+.hdlist table tr .hdlist2 {
+  padding-top: var(--base-small-space);
+  padding-bottom: var(--base-small-space);
+}
+
 .hdlist1,
 .hdlist2 {
   vertical-align: top;


### PR DESCRIPTION
Changed the CSS to add spaces to horizontal lists. Note that standard lists should not be affected as they are not built as tables.

https://issues.couchbase.com/browse/DOC-10177
