### PR TITLE
DOC-10280 Line up the definitions for second-level lists.

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -588,10 +588,6 @@ ul ul ul {
   margin: 0;
 }
 
-.hdlist table .hdlist1 + .hdlist2 p {
-  margin-left: var(--base-space);
-}
-
 .hdlist table tr .hdlist1,
 .hdlist table tr .hdlist2 {
   padding: var(--base-small-space) 0;


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-10280

Fixes alignment problem with nested horizontal definition lists.