### PR TITLE
Add print styles

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -162,3 +162,34 @@ main p {
     font-size: 1.2rem;
   }
 }
+
+@media print {
+  @page {
+    margin: 2cm;
+  }
+
+  .nav,
+  .toc,
+  .footer,
+  .navbar,
+  .run-code,
+  .header-top-row {
+    display: none;
+  }
+
+  a {
+    color: #000;
+    text-decoration: underline;
+  }
+
+  h2 {
+    break-after: avoid;
+  }
+
+  table,
+  img,
+  code,
+  svg {
+    break-inside: avoid;
+  }
+}

--- a/src/css/table.css
+++ b/src/css/table.css
@@ -204,7 +204,7 @@ table.table-tutorial tr td:last-child {
   }
 }
 
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 767px), print {
   table.tableblock td,
   table.tableblock th {
     line-height: 1.5em;


### PR DESCRIPTION
Adds a basic print style that hides the nav which currently breaks printing. No other layouts should be impacted. 


<img width="1060" alt="Screen Shot 2022-08-08 at 4 36 10 PM" src="https://user-images.githubusercontent.com/6208288/183500701-fa34bf9d-dbd3-44c4-b335-f929358286ec.png">

