### PR TITLE
Add Page Type Tags to Content

### DIFF
--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -2,6 +2,7 @@
 :doctype: book
 :page-edition: enterprise
 :page-status: beta
+:page-topic-type: guide
 :page-pagination:
 :page-toclevels: 2
 

--- a/src/css/labels.css
+++ b/src/css/labels.css
@@ -87,6 +87,34 @@
   opacity: 0.6;
 }
 
+.doc .concept {
+  color: var(--color-yellow);
+  border: 1px solid var(--color-yellow);
+  border-radius: 3px;
+  opacity: 0.6;
+}
+
+.doc .guide {
+  color: var(--color-brand-pink);
+  border: 1px solid var(--color-brand-pink);
+  border-radius: 3px;
+  opacity: 0.6;
+}
+
+.doc .tutorial {
+  color: var(--color-brand-green);
+  border: 1px solid var(--color-brand-green);
+  border-radius: 3px;
+  opacity: 0.6;
+}
+
+.doc .reference {
+  color: var(--color-brand-purple);
+  border: 1px solid var(--color-brand-purple);
+  border-radius: 3px;
+  opacity: 0.6;
+}
+
 .doc .edition.page-edition {
   color: #999;
   border: 1px solid #999;

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -46,6 +46,7 @@
   --color-code: var(--color-brand-pink);
   --color-border: var(--color-brand-silver);
   --checkbox-border-color: var(--color-brand-gray9);
+  --color-yellow: #d2a908;
 
   /* Color for URL */
   --color-link: var(--color-brand-blue-secondary);

--- a/src/partials/labels.hbs
+++ b/src/partials/labels.hbs
@@ -7,6 +7,15 @@
 {{#with page.attributes.status}}
 <li class="status"><span>{{{this}}}</span></li>
 {{/with}}
+{{#if (eq page.attributes.topic-type 'concept')}}
+<li class="concept"><span><i class="far fa-lightbulb"></i> concept</span></li>
+{{else if (eq page.attributes.topic-type 'tutorial')}}
+<li class="tutorial"><span><i class="fas fa-book-reader"></i> tutorial</span></li>
+{{else if (eq page.attributes.topic-type 'guide')}}
+<li class="guide"><span><i class="far fa-check-square"></i> how-to</span></li>
+{{else}}
+<li class="reference"><span><i class="fas fa-book"></i></i> reference</span></li>
+{{/if}}
 </ul>
 </div>
 {{/if}}

--- a/src/partials/labels.hbs
+++ b/src/partials/labels.hbs
@@ -7,7 +7,11 @@
 {{#with page.attributes.status}}
 <li class="status"><span>{{{this}}}</span></li>
 {{/with}}
-{{#if (eq page.attributes.topic-type 'concept')}}
+</ul>
+</div>
+{{/if}}
+<div class="labels">
+<ul>{{#if (eq page.attributes.topic-type 'concept')}}
 <li class="concept"><span><i class="far fa-lightbulb"></i> concept</span></li>
 {{else if (eq page.attributes.topic-type 'tutorial')}}
 <li class="tutorial"><span><i class="fas fa-book-reader"></i> tutorial</span></li>
@@ -18,4 +22,4 @@
 {{/if}}
 </ul>
 </div>
-{{/if}}
+


### PR DESCRIPTION
This PR is to merge the work on adding content tags/badges to pages in the documentation UI, based on the `page-topic-type` attribute value. 

![Untitled](https://user-images.githubusercontent.com/110928505/191982510-239001eb-b69b-4aa6-8c12-11072d228f81.png)
![image](https://user-images.githubusercontent.com/110928505/191982707-3afb3914-1b0e-4555-8be3-71e11ca54a35.png)

Badges display with or without the existing labels for `page-edition` and `page-status`. 