### PR TITLE
Add Consistency to Topic Labels Rendering 

### DIFF
--- a/src/css/labels.css
+++ b/src/css/labels.css
@@ -3,7 +3,7 @@
   display: flex;
   list-style: none;
   margin: 0;
-  padding: 0.125rem 0 0;
+  padding: 0.75rem 0 0;
 }
 
 .doc .labels li,
@@ -18,7 +18,7 @@
 .doc .edition,
 .doc .status,
 .doc .edition.page-edition {
-  max-width: fit-content;
+  /* max-width: fit-content; */
   font-size: var(--labels-font-size);
   font-weight: var(--weight-bold);
   line-height: var(--labels-line-height);

--- a/src/partials/labels.hbs
+++ b/src/partials/labels.hbs
@@ -1,15 +1,4 @@
-{{#if (or page.attributes.edition page.attributes.status)}}
-<div class="labels">
-<ul>
-{{#with page.attributes.edition}}
-<li class="edition"><a href="https://www.couchbase.com/products/editions">{{{this}}}</a></li>
-{{/with}}
-{{#with page.attributes.status}}
-<li class="status"><span>{{{this}}}</span></li>
-{{/with}}
-</ul>
-</div>
-{{/if}}
+{{#if (or page.attributes.topic-type)}}
 <div class="labels">
 <ul>{{#if (eq page.attributes.topic-type 'concept')}}
 <li class="concept"><span><i class="far fa-lightbulb"></i> concept</span></li>
@@ -24,8 +13,21 @@
 {{else if (eq page.attributes.topic-type 'reference')}}
 <li class="reference"><span><i class="fas fa-book"></i></i> reference</span></li>
 {{else}}
-<li></li>
 {{/if}}
 </ul>
 </div>
+{{/if}}
+{{#if (or page.attributes.edition page.attributes.status)}}
+<div class="labels">
+<ul>
+{{#with page.attributes.edition}}
+<li class="edition"><a href="https://www.couchbase.com/products/editions">{{{this}}}</a></li>
+{{/with}}
+{{#with page.attributes.status}}
+<li class="status"><span>{{{this}}}</span></li>
+{{/with}}
+</ul>
+</div>
+{{/if}}
+
 


### PR DESCRIPTION
Changed top padding value for labels in labels.css so that labels display nicely on a new line with a long topic title.

Commented out `max-width` value for labels in labels.css so "enterprise edition" label appears all as one line.

Changed labels.hbs so that topic type labels appear first.

![image](https://user-images.githubusercontent.com/110928505/192339397-99cd2efc-3d9b-40c4-8aa3-e25640054b64.png)
![image](https://user-images.githubusercontent.com/110928505/192339433-cb9974c9-f801-4d13-ac01-b16e9952d0da.png)
