### PR TITLE
DOC-10410: N1QL to SQL++ Rebrand

### DIFF
--- a/src/js/07-copy-to-clipboard.js
+++ b/src/js/07-copy-to-clipboard.js
@@ -1,7 +1,7 @@
 ;(function () {
   'use strict'
   var runCodeLangs = { cpp: 'cc', csharp: 'dotnet', js: 'nodejs', python: 'py', ruby: 'rb' }
-  var displayLangs = { sqlpp: 'sql++', n1ql: 'sql++' }
+  var displayLangs = { sqlpp: 'sql++' }
   var main = document.querySelector('main.article')
   document.querySelectorAll('pre > code').forEach(function (codeBlock) {
     var pre = codeBlock.parentNode


### PR DESCRIPTION
Follow-up to #149 

The previous UI bundle altered the string `N1QL` or `SQLPP` to `SQL++` in the `dataSource` span when the code block is being constructed.

That is incorrect, as the same UI bundle is used for all versions of the documentation. That would lead to an inconsistent situation, where older versions of the documentation would use `N1QL` in the running text, but `SQL++` for code blocks.

With this PR, code blocks where the code is marked up as `N1QL` will be labelled as `N1QL` in the output, and code blocks where the code is marked up as `SQLPP` will be labelled as `SQL++` in the output, matching the running text in all versions.
Note that this change does not alter the actual highlighting of the code in any way.