### PR TITLE
Add 'DEBUG' flag output

### DIFF
--- a/src/partials/main.hbs
+++ b/src/partials/main.hbs
@@ -22,5 +22,67 @@
 <div class="article-header">
 {{> crumbs}}
 </div>
+{{#if env.DEBUG}}
+<dl>
+    <dt>page.component = {{page.component.name}}</dt>
+    <dd>
+        <dl>
+            <dt>title</dt>
+            <dd>{{page.component.title}}</dd>
+            <dt>url</dt>
+            <dd>{{page.component.url}}</dd>
+            <dt>latest</dt>
+            <dd>{{page.component.latest}}</dd>
+            <dt>versions</dt>
+            <dd>{{page.component.versions}}</dd>
+        </dl>
+    </dd>
+
+    
+    <dt>page.componentVersion</dt>
+    <dd>
+        <dl>
+            {{#each page.componentVersion}}
+            <dt>{{@key}}</dt>
+            <dd>{{this}}</dd>
+            {{/each}}
+        </dl>
+    </dd>
+
+    <dt>page.version</dt>
+    <dd>{{page.version}}</dd>
+    
+    <dt>page</dt>
+    <dd>
+        <dl>
+            <dt>module</dt>
+            <dd>{{page.module}}</dd>
+            <dt>url</dt>
+            <dd>{{page.url}}</dd>
+            <dt>version</dt>
+            <dd>{{page.version}}</dd>
+            <dt>fileUri</dt>
+            <dd>{{page.fileUri}}</dd>
+        </dl>
+    </dd>
+
+    <dt>antoraVersion</dt>
+    <dd>{{antoraVersion}}</dd>
+    
+    <dt>site.components</dt>
+    <dd>        
+        <dl>
+            {{#each site.components}}
+            <dt>{{@key}}</dt>
+            <dd>{{this}}</dd>
+            {{/each}}
+        </dl>
+    </dd>
+    
+    <dt>site.ui</dt>
+    <dd>{{site.ui.defaultLayout}} {{site.ui.url}}</dd>
+    
+</dl>
+{{/if}}
 {{> article}}
 </main>


### PR DESCRIPTION
Experimental flag used to output information about each page. (This only shows page variables, so doesn't currently track e.g. the source of includes. That would probably require an Antora extension.)

To build with this:

 - in docs-ui checkout, run `npx gulp bundle`

 - in docs-site run `DEBUG=1 antora --ui-bundle-url ../docs-ui/build/ui-bundle.zip`

(This is experimental, for purpose of debugging @sarahlwelton's build issues, but might be generally useful?)