### PR TITLE
Change [abstract] attribute styling in Couchbase Documentation

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -494,15 +494,16 @@ ul ul ul {
 }
 
 .doc .quoteblock {
-  margin-top: var(--base-medium-space);
+  margin-top: var(--base-extra-large-space);
 }
 
 .doc .abstract blockquote {
-  font-size: 0.9375rem;
+  /* font-size: 0.9375rem; */
   margin: 0;
-  font-weight: var(--weight-light);
-  border-left: 2px solid var(--color-brand-gray5);
+  /* font-weight: var(--weight-light);
+  border-left: 2px solid var(--color-brand-gray5); */
   padding-left: 1.125rem;
+  padding-right: 6.125rem;
 }
 
 .doc .quoteblock + .paragraph {
@@ -512,11 +513,15 @@ ul ul ul {
 .doc blockquote * {
   font-weight: inherit;
 }
-/* .doc .abstract blockquote::before {
-  content: "Summary: ";
+/* 
+ .doc .abstract blockquote::before {
+  content: "Quick Summary \a";
+  white-space: pre;
   color: var(--color-muted);
   font-weight: var(--weight-medium);
-} */
+  font-size: var(--heading-h4);
+  padding-bottom: 1rem;
+}  */
 
 .doc ul {
   margin: 0;

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -498,12 +498,7 @@ ul ul ul {
 }
 
 .doc .abstract blockquote {
-  /* font-size: 0.9375rem; */
   margin: 0;
-  /* font-weight: var(--weight-light);
-  border-left: 2px solid var(--color-brand-gray5); */
-  padding-left: 1.125rem;
-  padding-right: 6.125rem;
 }
 
 .doc .quoteblock + .paragraph {
@@ -513,6 +508,11 @@ ul ul ul {
 .doc blockquote * {
   font-weight: inherit;
 }
+
+
+/* Use this for a working pseudo element before an [abstract] attribute-marked block in the documentation.
+  This one adds the words "Quick Summary" before any text inside the [abstract] block. */
+
 /* 
  .doc .abstract blockquote::before {
   content: "Quick Summary \a";


### PR DESCRIPTION
Modified CSS for .doc .quoteblock and .doc .abstract blockquote

Trialed some changes for .doc .abstract blockquote::before pseudo element, but ultimately commented them out.

There for future reference.

Images for reference of the change: 

![image](https://user-images.githubusercontent.com/110928505/220764780-d069f983-b0b4-45bb-90c9-877e2de71f42.png)
(before)

![image](https://user-images.githubusercontent.com/110928505/220764597-4451b6be-eebc-4a94-93fb-b34ff5611cf9.png)
(after)