### PR TITLE
AV-56084: integrate new GA4 script

### DIFF
--- a/src/partials/head-first.hbs
+++ b/src/partials/head-first.hbs
@@ -1,7 +1,13 @@
 <meta charset="utf-8">
 <meta http-equiv=content-security-policy content="default-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline' https:; font-src 'self' https://fonts.gstatic.com; frame-src 'self' https:; img-src 'self' data: https:; connect-src 'self' https:; worker-src blob:;">
 <meta name="viewport" content="width=device-width,initial-scale=1.0">
+
 {{#with site.keys.googleAnalytics}}
-<script>(window.dataLayer=window.dataLayer||[]).push({event:'gtm.js','gtm.start':+new Date()})</script>
-<script async src="https://www.googletagmanager.com/gtm.js?id={{{this}}}"></script>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://metrics.couchbase.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','{{{this}}}');</script>
+<!-- End Google Tag Manager -->
 {{/with}}


### PR DESCRIPTION
As discussed, this uses the same GA id as before
(templated here as `site.keys.googleAnalytics` and inserted as `{{{this}}}`)

Note that:

* the script is now included from Couchbase's own servers (managed by Annie Obendorf, James Oquendo et al)
Have checked that https://metrics.couchbase.com/gtm.js?id={our ID} resolves.

* we have been informed that the new script will handle writing the data to both old (UA) and new (GA4) systems.