### PR TITLE
AV-56547: Add Info Banner Styling

### DIFF
--- a/src/css/info-banner.css
+++ b/src/css/info-banner.css
@@ -1,0 +1,26 @@
+.info-banner {
+  display: block;
+  border: 1px solid #e5e5e5;
+  border-radius: 3px;
+  -webkit-box-shadow: 0 3px 10px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.06);
+  background-image: linear-gradient(to right, #00ace0, #636cdc);
+  padding: 0.75em;
+  margin-top: 0;
+  margin-bottom: 1em;
+}
+
+.doc.landing-page-doc .info-banner p {
+  text-align: center;
+  color: white;
+  font-weight: lighter;
+}
+
+.info-banner a {
+  color: white;
+  font-size: 18px;
+  font-weight: bold;
+  display: inline-block;
+  border: solid 1px white;
+  padding: 0.5em 1em;
+}

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -34,3 +34,4 @@
 @import "external-link-icon.css";
 @import "disable-callouts.css";
 @import "asciidoctor-external-callout.css";
+@import "info-banner.css";


### PR DESCRIPTION
See https://github.com/couchbase/docs-site/pull/704 which reverts the temporary banner and removes the inline CSS.

As promised, this commit finally extracts that CSS into docs-ui, so that it is ready for the next time we use the banner.