### PR TITLE
AV-75840 top nav highlight

### DIFF
--- a/src/css/header.css
+++ b/src/css/header.css
@@ -42,6 +42,9 @@
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
+}
+
+.navbar-new-top {
   padding: 0.5rem 0;
 }
 
@@ -83,6 +86,7 @@
 
 .navbar-new-bottom .nav-item {
   margin: 0 var(--base-space);
+  padding: 0.5rem;
 }
 
 .navbar-nav .nav-link {
@@ -213,6 +217,10 @@
   left: -0.75em;
 }
 
+.nav-item-selected {
+  background-color: var(--color-brand-red);
+}
+
 @media screen and (min-width: 1024px) {
   .navbar-start > a.navbar-item:hover,
   .navbar-start > .navbar-item:hover > .navbar-link {
@@ -267,7 +275,7 @@
 }
 
 @media screen and (max-width: 992px) {
-  .navbar {
+  .navbar-new-top {
     padding: 0.8rem 0;
   }
 

--- a/src/css/header.css
+++ b/src/css/header.css
@@ -85,8 +85,8 @@
 }
 
 .navbar-new-bottom .nav-item {
-  margin: 0 var(--base-space);
-  padding: 0.5rem;
+  margin: 0 var(--base-extra-small-space);
+  padding: var(--base-extra-small-space) var(--base-space);
 }
 
 .navbar-nav .nav-link {
@@ -297,12 +297,6 @@
 
   .navbar-collapse {
     width: 100%;
-  }
-
-  .navbar-new-bottom .nav-item {
-    padding: 0 15px;
-    width: 100%;
-    margin: 10px 0;
   }
 
   .search {

--- a/src/helpers/includes.js
+++ b/src/helpers/includes.js
@@ -1,3 +1,5 @@
 'use strict'
 
-module.exports = (haystack, needle) => ~(haystack || '').indexOf(needle)
+module.exports = (haystack, needle) => {
+  return ~(haystack || '').indexOf(needle)
+}

--- a/src/helpers/nav-group-selected.js
+++ b/src/helpers/nav-group-selected.js
@@ -1,0 +1,22 @@
+'use strict'
+
+module.exports = module.exports = (navGroup, {
+  data: {
+    root: { page, site },
+  },
+}) => {
+  if (navGroup === 'home') {
+    // FAKE value to signal that we instead check all the navgroups
+    const navGroups = site.keys.navGroups
+    // NB this must be called after nav-groups has already prepared the data (:scream:)
+    const possible = navGroups.filter((it) => selected(it, page))
+    return possible.length === 1 && possible[0].title === 'Home'
+  } else {
+    return selected(navGroup, page)
+  }
+}
+
+function selected (navGroup, page) {
+  return (navGroup.url === page?.url) ||
+    (navGroup.components?.includes(page.component?.name))
+}

--- a/src/helpers/nav-group-selected.js
+++ b/src/helpers/nav-group-selected.js
@@ -8,7 +8,8 @@ module.exports = module.exports = (navGroup, {
   if (navGroup === 'home') {
     // FAKE value to signal that we instead check all the navgroups
     const navGroups = site.keys.navGroups
-    // NB this must be called after nav-groups has already prepared the data (:scream:)
+    // NB this relies on variable stored in site.keys, so must be called
+    // *after* nav-groups has already prepared the data
     const possible = navGroups.filter((it) => selected(it, page))
     return possible.length === 1 && possible[0].title === 'Home'
   } else {

--- a/src/helpers/nav-groups.js
+++ b/src/helpers/nav-groups.js
@@ -2,7 +2,7 @@
 
 module.exports = ({
   data: {
-    root: { contentCatalog = { resolvePage: () => undefined }, site },
+    root: { contentCatalog = { resolvePage: () => undefined }, site, page },
   },
 }) => {
   let navGroups = site.keys.navGroups
@@ -42,6 +42,8 @@ module.exports = ({
     }
   }
   navGroups._compiled = true
+  console.log(navGroups)
+  console.log(page)
   return (site.keys.navGroups = navGroups)
 }
 

--- a/src/helpers/nav-groups.js
+++ b/src/helpers/nav-groups.js
@@ -2,29 +2,34 @@
 
 module.exports = ({
   data: {
-    root: { contentCatalog = { resolvePage: () => undefined }, site, page },
+    root: { contentCatalog = { resolvePage: () => undefined }, site },
   },
 }) => {
   let navGroups = site.keys.navGroups
+
   if (!navGroups) return []
   if (navGroups._compiled) return navGroups
+
   const components = site.components
   const componentNames = Object.keys(components)
   const claimed = []
-  navGroups = JSON.parse(navGroups).reduce((accum, navGroup) => {
-    const componentNamesInGroup = (navGroup.components || []).reduce((matched, componentName) => {
-      if (~componentName.indexOf('*')) {
-        const rx = new RegExp(`^${componentName.replace(/[*]/g, '.*?')}$`)
-        return matched.concat(componentNames.filter((candidate) => rx.test(candidate)))
-      } else if (componentName in components) {
-        return matched.concat(componentName)
-      }
-      return matched
-    }, [])
+
+  navGroups = JSON.parse(navGroups).map((navGroup) => {
+    const componentNamesInGroup =
+      (navGroup.components || []).flatMap(
+        (componentName) => componentNames.filter(globbify(componentName)))
+
     claimed.push(...componentNamesInGroup)
-    return accum.concat(compileNavGroup(navGroup, componentNamesInGroup, contentCatalog, components))
-  }, [])
-  const orphaned = componentNames.filter((it) => claimed.indexOf(it) < 0)
+
+    return compileNavGroup(
+      navGroup,
+      componentNamesInGroup,
+      contentCatalog,
+      components)
+  })
+
+  const orphaned = componentNames.filter((it) => !claimed.includes(it))
+
   if (orphaned.length) {
     const homeIdx = orphaned.indexOf('home')
     if (~homeIdx) {
@@ -41,25 +46,36 @@ module.exports = ({
         : navGroups.push(compileNavGroup({ title: 'General' }, orphaned, contentCatalog, components))
     }
   }
+
   navGroups._compiled = true
   console.log(navGroups)
-  console.log(page)
-  return (site.keys.navGroups = navGroups)
+
+  site.keys.navGroups = navGroups
+  return navGroups
 }
 
 function compileNavGroup (navGroup, componentNamesInGroup, contentCatalog, components) {
-  navGroup.components = componentNamesInGroup
   let startPage = navGroup.startPage
   if (startPage) {
     startPage = contentCatalog.resolvePage(startPage)
     if (startPage) navGroup.url = startPage.pub.url
     delete navGroup.startPage
   }
+
+  navGroup.components = componentNamesInGroup
   if (componentNamesInGroup.length) {
     navGroup.latestVersions = componentNamesInGroup.reduce((latestVersionMap, it) => {
       latestVersionMap[it] = components[it].latest.version
       return latestVersionMap
     }, {})
   }
+  // if ((navGroup.url === page?.url) || componentNamesInGroup.includes(page.component.name)) {
+  //   navGroup.selected = true
+  // }
   return navGroup
+}
+
+function globbify (componentName) {
+  const rx = new RegExp(`^${componentName.replace(/[*]/g, '.*?')}$`)
+  return (it) => rx.test(it)
 }

--- a/src/helpers/nav-groups.js
+++ b/src/helpers/nav-groups.js
@@ -48,7 +48,6 @@ module.exports = ({
   }
 
   navGroups._compiled = true
-  console.log(navGroups)
 
   site.keys.navGroups = navGroups
   return navGroups
@@ -69,9 +68,6 @@ function compileNavGroup (navGroup, componentNamesInGroup, contentCatalog, compo
       return latestVersionMap
     }, {})
   }
-  // if ((navGroup.url === page?.url) || componentNamesInGroup.includes(page.component.name)) {
-  //   navGroup.selected = true
-  // }
   return navGroup
 }
 

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -33,16 +33,17 @@
 
               <div class="navbar-collapse collapse" id="navbar2">
                 <ul class="navbar-nav w-100 justify-content-start">
-                  <li class="nav-item">
+                  <li class="nav-item {{#if (eq "home" page.component.name)}}nav-item-selected{{/if}}"">
                     <a href="{{#with (and site.url site.homeUrl)}}{{@root.site.url}}{{this}}{{else}}{{siteRootPath}}{{/with}}" class="nav-link">
                       <i class="fas fa-home"></i>
                     </a>
                   </li>
                   {{#each (nav-groups)}}
                   {{#if ./url}}
-                  <li class="nav-item">
+                  <li class="nav-item {{#if (or (eq ./url @root.page.url) (includes ./components @root.page.component.name))}}nav-item-selected{{/if}}">
                     <a class="nav-link" href="{{relativize ./url}}">
                       {{{./title}}}
+                      
                       {{#if (eq ./title 'Tutorials')}}
                       <span class="arrow">
                         <i class="fas fa-arrow-right"></i>

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -9,7 +9,8 @@
                   </a>
                 </li>
                 <li>
-                  <a class="navbar-brand cb-documentation" href="{{#with (and site.url site.homeUrl)}}{{{@root.site.url}}}{{{this}}}{{else}}{{{siteRootPath}}}{{/with}}">
+                  <a class="navbar-brand cb-documentation"
+                      href="{{#if (and site.url site.homeUrl)}}{{{site.url}}}{{{site.homeUrl}}}{{else}}{{{siteRootPath}}}{{/if}}">
                     <img src="{{{uiRootPath}}}/img/cb-documentation.svg" alt="Couchbase Documentation" class="cb-docs" />
                     <img src="{{{uiRootPath}}}/img/cb-docs-hover.svg" alt="Couchbase Documentation" class="hide cb-hover-docs" />
                   </a>
@@ -33,14 +34,16 @@
 
               <div class="navbar-collapse collapse" id="navbar2">
                 <ul class="navbar-nav w-100 justify-content-start">
-                  <li class="nav-item {{#if (eq "home" page.component.name)}}nav-item-selected{{/if}}"">
-                    <a href="{{#with (and site.url site.homeUrl)}}{{@root.site.url}}{{this}}{{else}}{{siteRootPath}}{{/with}}" class="nav-link">
+                  {{#with (nav-groups)}}
+
+                  <li class="nav-item {{#if (nav-group-selected "home")}}nav-item-selected{{/if}}"">
+                    <a href="{{#if (and @root.site.url @root.site.homeUrl)}}{{@root.site.url}}{{@root.site.homeUrl}}{{else}}{{siteRootPath}}{{/if}}" class="nav-link">
                       <i class="fas fa-home"></i>
                     </a>
                   </li>
-                  {{#each (nav-groups)}}
+                  {{#each this}}
                   {{#if ./url}}
-                  <li class="nav-item {{#if (or (eq ./url @root.page.url) (includes ./components @root.page.component.name))}}nav-item-selected{{/if}}">
+                  <li class="nav-item {{#if (nav-group-selected this)}}nav-item-selected{{/if}}">
                     <a class="nav-link" href="{{relativize ./url}}">
                       {{{./title}}}
                       
@@ -53,6 +56,7 @@
                   </li>
                   {{/if}}
                   {{/each}}
+                  {{/with}}
                 </ul>
               </div>
               <div class="primary-action">


### PR DESCRIPTION
This PR adds a highlight to the top nav for which section we're in:

You can currently see it in action on Staging:
![image](https://github.com/couchbase/docs-ui/assets/28139/9548b2d1-a7ed-48ed-a94d-a7c156ba9cc8)

The logic used is:

* check the Nav Groups (defined in antora-playbook.yml e.g. https://github.com/couchbase/docs-site/blob/master/antora-playbook-staging.yml#L22-L29 )
* if the current component matches the `components` key, then it's highlighted
* but also the "index pages" like https://docs-staging.couchbase.com/home/sdk.html are in the `home` component...
So we ALSO need to check if the `url` matches the page
* this means that the `home` component has to have special handling, where we check if it (and ONLY it) could be highlighted