### PR TITLE
DOC-12226 disambiguate code links

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -72,6 +72,11 @@ code {
   color: var(--color-brand-gray1);
 }
 
+a code {
+  color: var(--color-link);
+  background-color: transparent;
+}
+
 html code {
   hyphens: none;
 }


### PR DESCRIPTION
Code links are hard to see because they look like code, and not like links. We override `a code` to reset the link formatting for this case.