### PR TITLE
DOC-12087: Add Windows batch file highlighting

### DIFF
--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -40,6 +40,15 @@ index-pair ::= '"' 'indexes' '"' ':' ( 'null'
 ----
 ====
 
+.Here is a bit of a Microsoft Windows Batch File
+====
+[,cmd]
+----
+cd couchbase-server-tools\bin
+cbq -u %USER% -p %PASSWORD% -e %BASE_URL% --cacert %CACERT% -skip-verify
+----
+====
+
 [[bucket-selection]]Bucket Selection::
 The [.ui]*Buckets* selection list lets you select which of the buckets configured on your cluster is to be used as the basis for the graph display.
 The statistics shown are aggregated over the whole cluster for the <<bucket-selection,selected bucket>>.

--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -196,14 +196,12 @@ You could also use it to mark new features, but _only within the version in whic
 
 == Labels for a Section
 
-[.labels]
 [.edition]##{enterprise}##[.status]##{developer-preview}##
 
 To create an edition label, use a span with the role `edition`.
 To create a status label, use a span with the role `status`.
 
 To add edition and status labels at the start of a section or block, place the required spans in a single paragraph on its own.
-To add the "speech bubble tail" above the labels, the spans should be placed in a paragraph with the role `labels`.
 
 Global document attributes are available to insert the content for an edition or status label.
 The global document attribute `&lbrace;enterprise&rbrace;` inserts the content for an enterprise edition label.
@@ -445,7 +443,7 @@ POST http://nodename:8091/settings/viewUpdateDaemon
 updateInterval=10000&updateMinChanges=7000
 ----
 
-[.no-callouts,json5]
+[.no-callouts,json]
 ----
 {
    "_id": "_design/myddoc",

--- a/src/js/vendor/highlight.bundle.js
+++ b/src/js/vendor/highlight.bundle.js
@@ -7,6 +7,7 @@
   hljs.registerLanguage('cpp', require('highlight.js/lib/languages/cpp'))
   hljs.registerLanguage('cs', require('highlight.js/lib/languages/cs'))
   hljs.registerLanguage('dockerfile', require('highlight.js/lib/languages/dockerfile'))
+  hljs.registerLanguage('dos', require('highlight.js/lib/languages/dos'))
   hljs.registerLanguage('ebnf', require('highlight.js/lib/languages/ebnf'))
   hljs.registerLanguage('go', require('highlight.js/lib/languages/go'))
   hljs.registerLanguage('groovy', require('highlight.js/lib/languages/groovy'))


### PR DESCRIPTION
This PR arose out of work I was doing for the cbq file, but has wider implications for future compatibility, especially if we're going to have to provide Windows batch file examples for customers who can't use WSL.