### PR TITLE
[DOC-12578]: Scrunched up title on admonition block.

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -342,6 +342,7 @@ ul ul ul {
 .doc .admonitionblock td.content > .title {
   display: inline;
   font-style: italic;
+  margin-left: var(--admonition-icon-text-space);
 }
 
 .doc .admonitionblock td.content > .title::after {

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -140,6 +140,7 @@
   --column-space: 2.5rem; /* ~ 40px */
   --admonition-icon-space: 1rem; /* ~ 16px */
   --admonition-content-space: 1rem; /* ~ 16px */
+  --admonition-icon-text-space: 0.1rem; /* ~ 1.6px */
 
   /* Heading fonts for responsive */
   --heading-h1-sm: 2.25rem; /* ~36px */


### PR DESCRIPTION
Changes to the CSS to open a gap in the admonition title block.
(Admonition titles don't get used that often.)

Changing this:

<img width="1256" alt="image" src="https://github.com/user-attachments/assets/dada7d6a-8d11-46f8-a1d1-895af871f8cd">

to this:

<img width="1256" alt="image" src="https://github.com/user-attachments/assets/3aded963-0b1c-4d14-8a16-47a17d289a00">
