### PR TITLE
UI: Special case landing page of 4 .card-box

### DIFF
--- a/src/css/landing-page.css
+++ b/src/css/landing-page.css
@@ -407,6 +407,15 @@
   .doc.landing-page-capella .card-box {
     width: 30%;
   }
+
+  /* special case container with 4 cards to be 2x2 even on wide screen */
+  .doc.landing-page-capella .card-container:has(.card-box:nth-child(4)) .card-box {
+    width: 46%;
+  }
+
+  .doc.landing-page-capella .card-container:has(.card-box:nth-child(5)) .card-box {
+    width: 30%;
+  }
 }
 
 /* CSS for nav filter */


### PR DESCRIPTION
Request via @RichardSmedley to make e.g. this page https://preview.docs-test.couchbase.com/sdk-test/home/developer-docs.html show as 2x2 rather than 3+1 when stretched to widest setting.

PR approach is to give an override of width for a list with a 4th item, and then another override for a list with a 5th item.
e.g. the intent is to special-case only 4 cards.

Is this sensible/silly?