### PR TITLE
DOC-13219 set kroki image width to 100%

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -475,6 +475,10 @@ ul ul ul {
   max-width: 100%;
 }
 
+.imageblock.kroki img {
+  width: 100%;
+}
+
 .doc span.image.icon {
   line-height: 1;
   vertical-align: -0.2em;


### PR DESCRIPTION
I've updated this on Staging, e.g. https://docs-staging.couchbase.com/server/current/learn/services-and-indexes/services/analytics-service.html

Please could you look at Kroki (e.g. PlantUML or Mermaid) diagrams in your area, and see if this change has broken anything?