### PR TITLE
DOC-13347 fix unreadable inline example

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -78,6 +78,11 @@ code {
   color: inherit;
 }
 
+#redoc .hljs-comment,
+#redoc .hljs-meta {
+  color: inherit;
+}
+
 a code {
   color: var(--color-link);
   background-color: transparent;

--- a/src/css/table.css
+++ b/src/css/table.css
@@ -153,7 +153,7 @@ table.table-tutorial tr td:last-child {
 
 /* Responsive css  */
 
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 1px /*768px*/) {
   table.tableblock {
     display: table;
     position: relative;
@@ -212,6 +212,7 @@ table.table-tutorial tr td:last-child {
   }
 }
 
+/* This "responsive" table CSS is a bit odd, I'm not sure it is needed any more:
 @media screen and (max-width: 767px), print {
   table.tableblock td,
   table.tableblock th {
@@ -242,3 +243,4 @@ table.table-tutorial tr td:last-child {
     max-width: 120px;
   }
 }
+*/


### PR DESCRIPTION
Our highlightjs style breaks redocly inline examples, so we ensure it is ignored.

Q: should we instead disable highlightjs for these pages?

Bundled DOC-13355 in subsequent commit